### PR TITLE
モバイルでタブがはみ出る問題を修正

### DIFF
--- a/packages/frontend/src/pages/ProjectPage.tsx
+++ b/packages/frontend/src/pages/ProjectPage.tsx
@@ -130,7 +130,7 @@ export const ProjectPage = () => {
 
       {/* タブナビゲーション */}
       <div className="border-b border-gray-200 mb-8">
-        <nav className="-mb-px flex space-x-8" aria-label="Tabs">
+        <nav className="-mb-px flex space-x-8  overflow-x-auto flex-nowrap" aria-label="Tabs">
           <Link
             to={`/projects/${projectId}/overall`}
             className={`


### PR DESCRIPTION
close #18 

# 変更の概要
- モバイルでレイアウトが崩れる問題を修正
- タブを横スクロールで触れるようにしました
- デスクトップでの見た目に変更はありません

https://github.com/user-attachments/assets/3daf27f9-ede5-4719-8f9f-ed0cd1d8ba82

# 変更の背景
- [モバイルでレイアウトが崩れるのを修正する](https://github.com/takahiroanno2024/idobata-analyst/issues/18)

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
