### PR TITLE
論点タブがはみ出る問題を修正

### DIFF
--- a/packages/frontend/src/components/StanceReport.tsx
+++ b/packages/frontend/src/components/StanceReport.tsx
@@ -144,7 +144,7 @@ export const StanceReport = ({ comments, project, initialQuestionId }: StanceAna
     <div className="space-y-6">
       {/* 論点選択タブ */}
       <div className="border-b border-gray-200">
-        <nav className="-mb-px flex space-x-4" aria-label="Tabs">
+        <nav className="-mb-px flex space-x-4 overflow-x-auto flex-nowrap" aria-label="Tabs">
           {project.questions.map((question, index) => (
             <button
               key={question.id}


### PR DESCRIPTION
close #42 
# 変更の概要
- 論点タブを横スクロールで触れるようにしました
- デスクトップでの見た目に変更はありません

# 変更の背景
- [モバイルで論点タブが崩れるのを修正する](https://github.com/takahiroanno2024/idobata-analyst/issues/42)

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
